### PR TITLE
Refresh the token before it expires

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -8,12 +8,16 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css">
     <script src="https://www.google.com/recaptcha/api.js?render=YOUR_RECAPTCHA_SITE_KEY"></script>
     <script>
-        grecaptcha.ready(function () {
-            grecaptcha.execute('YOUR_RECAPTCHA_SITE_KEY', { action: 'contact' }).then(function (token) {
-                var recaptchaResponse = document.getElementById('recaptchaResponse');
-                recaptchaResponse.value = token;
+        function loadRecaptchaToken() {
+            grecaptcha.ready(function () {
+                grecaptcha.execute('YOUR_RECAPTCHA_SITE_KEY', { action: 'contact' }).then(function (token) {
+                    var recaptchaResponse = document.getElementById('recaptchaResponse');
+                    recaptchaResponse.value = token;
+                });
             });
-        });
+        }
+        loadRecaptchaToken();
+        setInterval(function(){loadRecaptchaToken();}, 100000);
     </script>
 </head>
 


### PR DESCRIPTION
The recaptcha response (token) is only valid for 120 seconds after it's fetched. With the origiinal code, the token is only fetched once when the form is loaded; therefore, if a user submits the form more than 2 minutes after loading the page (which is a very common occurrence), the token would have expired and the recaptcha would systematically fail.  This commit fixes the issue by refreshing the token every 100 seconds.